### PR TITLE
Use valid post_date_gmt value when post_date is empty

### DIFF
--- a/lib/class-generator.php
+++ b/lib/class-generator.php
@@ -449,7 +449,7 @@ COMMENT;
 	 * @return bool
 	 */
 	protected function is_valid_date( $date ) {
-		if ( ! is_string( $date ) ) {
+		if ( ! is_string( $date ) || '' === $date ) {
 			return false;
 		}
 

--- a/lib/schema.json
+++ b/lib/schema.json
@@ -239,8 +239,7 @@
         {
           "name": "post_date",
           "type": "mysql_date",
-          "element": "wp:post_date",
-          "default": "now"
+          "element": "wp:post_date"
         },
         {
           "name": "post_date_gmt",
@@ -429,4 +428,3 @@
     }
   }
 }
-

--- a/phpunit/bootstrap.php
+++ b/phpunit/bootstrap.php
@@ -23,8 +23,8 @@ require_once $_tests_dir . '/includes/functions.php';
  * Manually load the plugin being tested.
  */
 function _manually_load_plugin() {
-	require dirname( dirname( __FILE__ ) ) . '/wxr-generator.php';
-	require dirname( dirname( __FILE__ ) ) . '/lib/class-buffer-writer.php';
+	require_once dirname( dirname( __FILE__ ) ) . '/wxr-generator.php';
+	require_once dirname( dirname( __FILE__ ) ) . '/lib/class-buffer-writer.php';
 }
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 

--- a/phpunit/tests/GeneratorTest.php
+++ b/phpunit/tests/GeneratorTest.php
@@ -167,7 +167,6 @@ class GeneratorTest extends WP_UnitTestCase {
 				'title'         => 'Test post',
 				'content'       => 'Test content',
 				'date'          => '2012-12-12 12:12:12',
-				'post_date'     => '',
 				'post_date_gmt' => '2012-12-12 12:12:12',
 			)
 		);
@@ -179,7 +178,7 @@ class GeneratorTest extends WP_UnitTestCase {
 		$item = $wxr->channel[0]->item[0];
 		$this->assertEquals( $item->pubDate, 'Wed, 12 Dec 2012 12:12:12 +0000' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 		$this->assertEquals( $item->children( 'wp', true )->post_date_gmt, '2012-12-12 12:12:12' );
-		$this->assertEquals( $item->children( 'wp', true )->post_date, '' ); // make sure node is empty.
+		$this->assertNotContains( '<wp:post_date/>', $wxr->asXML() ); // make sure post_date empty node is not present.
 	}
 
 	public function testCategories() {

--- a/phpunit/tests/GeneratorTest.php
+++ b/phpunit/tests/GeneratorTest.php
@@ -153,6 +153,35 @@ class GeneratorTest extends WP_UnitTestCase {
 		$this->assertEquals( $item->children( 'wp', true )->post_date, '2012-12-12 12:12:12' );
 	}
 
+	/**
+	 * This test ensures that post_date_gmt is used when present, and post_date
+	 * does not fill with an invalid `now` value.
+	 *
+	 * @throws OxymelException
+	 */
+	public function testPostDateGmt() {
+		$this->generator->initialize();
+
+		$this->generator->add_post(
+			array(
+				'title'         => 'Test post',
+				'content'       => 'Test content',
+				'date'          => '2012-12-12 12:12:12',
+				'post_date'     => '',
+				'post_date_gmt' => '2012-12-12 12:12:12',
+			)
+		);
+
+		$this->generator->finalize();
+
+		$wxr = simplexml_load_string( $this->writer->get_clear() );
+
+		$item = $wxr->channel[0]->item[0];
+		$this->assertEquals( $item->pubDate, 'Wed, 12 Dec 2012 12:12:12 +0000' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		$this->assertEquals( $item->children( 'wp', true )->post_date_gmt, '2012-12-12 12:12:12' );
+		$this->assertEquals( $item->children( 'wp', true )->post_date, '' ); // make sure node is empty.
+	}
+
 	public function testCategories() {
 		$this->generator->initialize();
 


### PR DESCRIPTION
When `post_date_gmt` is present, and `post_date` is empty, wxr-generator adds an automatic `now` value to `post_date`. This makes `post_date_gmt` and `post_date` have differing values in the generated XML, and hence makes it an invalid post date.

This PR:
1. Removes the automatic `now` default for `post_date`
2. Makes an empty string an invalid date.

which will fix the issue. This includes a test that can reproduce and fix the issue.

## Reference
See: D64061